### PR TITLE
animation resolver forward ref

### DIFF
--- a/packages/animation-plugin/src/index.tsx
+++ b/packages/animation-plugin/src/index.tsx
@@ -270,7 +270,7 @@ export class AnimationResolver implements IStyledPlugin {
 
   wrapperComponentMiddleWare() {
     const AnimatedPresenceComp = React.forwardRef(
-      ({ children, ...props }: any) => {
+      ({ children, ...props }: any, ref: any) => {
         const clonedChildren: any = [];
         const styledContext = useStyled();
         const CONFIG = useMemo(


### PR DESCRIPTION
animation resolver throw error: 
"forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?"
this solved problem for me